### PR TITLE
Server interaction

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -152,6 +152,7 @@ class AutoTester extends NodeState
         # to initial state
         console.log '[STATE] '+@current_state_name
         console.log 'Error has occured: ' + data.error
+        @goto 'Waiting'
 
 # Server Waits here for a /start request from Jenkins or pubnub
 # fsm = new AutoTester

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -10,10 +10,10 @@ writer = require '../lib/writer'
 # Config Stuff
 token = process.env.TOKEN
 pathToImg = '/data/test.img'
-parameters =
+netParams =
     network: 'wifi'
-    ssid: process.env.SSID
-    wifiKey: process.env.WIFI_KEY
+    ssid: process.env.SSID || 'Techspace'
+    wifiKey: process.env.WIFI_KEY || 'cak-wy-rum'
     appId: 9155
 
 class AutoTester extends NodeState
@@ -21,7 +21,10 @@ class AutoTester extends NodeState
     Initialize:
       #Check internet and connection to api, then login to resin
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        fsm = this
+        #Initialise the Internet connectivity tester
+        DeviceConn.init()
+        console.log '[STATE] '+@current_state_name
         physicalMedia.allOff()
         DeviceConn.hasInternet()
           .then (isConnected) ->
@@ -41,14 +44,15 @@ class AutoTester extends NodeState
     DownloadImage:
       # Check connection to api and internet, then download .img with cli/sdk
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        fsm = this
+        console.log '[STATE] '+@current_state_name
         @wait 200000 # timeout if a download takes longer than 20 minutes
         resin.auth.isLoggedIn (error, isLoggedIn) ->
           if error?
             fsm.goto 'ErrorState', {error: error}
 
           if isLoggedIn
-            resin.models.os.download(parameters).then (stream) ->
+            resin.models.os.download(netParams).then (stream) ->
               console.log 'Downloading device OS'
               stream.pipe(fs.createWriteStream(pathToImg))
               stream.on 'error', (err) ->
@@ -69,7 +73,8 @@ class AutoTester extends NodeState
     MountMedia:
       # pull GPIO high so Media disk is connected to Master USB
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        fsm = this
+        console.log '[STATE] '+@current_state_name
         physicalMedia.allOff()
         @wait 3000 # timeout if media takes too long to mount
 
@@ -90,7 +95,8 @@ class AutoTester extends NodeState
     WriteMedia:
       # Write to install media
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        fsm = this
+        console.log '[STATE] '+@current_state_name
         console.log 'Writing to Install Media: '+data.drive
         writer.writeImage pathToImg, {
           device: data.drive
@@ -104,7 +110,7 @@ class AutoTester extends NodeState
     EjectMedia:
       # Pull GPIO low so Media disk is disconnected from Master USB
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        console.log '[STATE] '+@current_state_name
         console.log 'Ejecting install media'
         physicalMedia.allOff()
         @goto 'PlugMediaIntoSlaveDevice'
@@ -112,7 +118,7 @@ class AutoTester extends NodeState
     PlugMediaIntoSlaveDevice:
       # Pull GPIO high so Media disk is now connected to slave ready to boot
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        console.log '[STATE] '+@current_state_name
         console.log 'Inserting install media into device'
         physicalMedia.connectSd()
         @goto 'PowerSlaveDevice'
@@ -120,32 +126,40 @@ class AutoTester extends NodeState
     PowerSlaveDevice:
       # apply power to slave, check that power is actually on, if it is
       # then go to successful test...lots could be done here to validate
+      # jenkins should wait about 2-3 minute for device to pop up in dash
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        console.log '[STATE] '+@current_state_name
         physicalMedia.powerSlave()
         # TODO: need to have a GPIO input to check that power is actually there
         @goto 'TestSuccess'
 
     TestSuccess:
       Enter: (data) ->
-        console.log '[STATE] '+fsm.current_state_name
+        console.log '[STATE] '+@current_state_name
         console.log 'Successfully provisioned Slave device'
-        fsm.stop()
+        @goto 'Waiting'
+
+    Waiting:
+      #Wait for a Test to be started
+      Enter: (data) ->
+        fsm = this
+        console.log '[STATE] '+@current_state_name
+        # @stop()
 
     ErrorState:
       Enter: (data) ->
         # Should report which state had the error and what it was, then return
         # to initial state
-        console.log '[STATE] '+fsm.current_state_name
+        console.log '[STATE] '+@current_state_name
         console.log 'Error has occured: ' + data.error
-        @goto 'Initialize'
 
 # Server Waits here for a /start request from Jenkins or pubnub
-fsm = new AutoTester
-  initial_data: {} #pass in test data here
-  initial_state: 'Initialize'
+# fsm = new AutoTester
+#   initial_data: {} #pass in test data here
+#   initial_state: 'Initialize'
 
-#Initialise the Internet connectivity tester
-DeviceConn.init()
-console.log 'Starting FSM'
-fsm.start()
+# #Initialise the Internet connectivity tester
+# DeviceConn.init()
+# console.log 'Starting FSM'
+# fsm.start()
+module.exports = AutoTester

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -1,0 +1,101 @@
+express = require 'express'
+AutoTester = require './main'
+
+startTime = 0
+data =
+  uuid: ""
+  log: null
+  state: null
+  error: ""
+  timeout: false
+  states: null
+  token: process.env.TOKEN
+  sTim: null
+  Utoken: process.env.TOKEN
+  appName: process.env.SLAVEAPP || 'rpiSlave'
+  img:
+    appId: process.env.SLAVE_APP_ID || 9155
+    network: "ethernet"
+    ssid: "Techspace"
+    wifiKey: "cak-wy-rum"
+    uiHost: "https://dashboard.resin.io"
+    apiHost: "https://api.resin.io"
+  credentials:
+    username: process.env.USERNAME
+    password: process.env.USER_PASS
+
+app = express()
+fsm = new AutoTester
+  initial_data: {data} #pass in test data here
+  initial_state: 'Waiting'
+
+app.get '/status', (req, res) ->
+  console.log "Got /status request"
+  res.send(data.state)
+
+app.get '/jstatus', (req, res) ->
+  console.log "Got /jstatus request"
+  resData =
+    state: data.state
+    error: data.error
+    started: time
+    now: Date.now()
+  res.json( resData )
+
+app.get '/tstatus', (req, res) ->
+  console.log "Got /tstatus request"
+  res.json( { timer: (data.sTim?) , timeout: data.Timeout } )
+
+app.get '/uuid', (req, res) ->
+  console.log "Got /uuid request"
+  res.json( { uuid: data.uuid } )
+
+# tests need this: jenkins will ping to check if device is online
+app.get '/ping', (req, res) ->
+  console.log "Got /ping request"
+  if !fsm.current_state_name?
+    mode = "free"
+  else
+    mode = "testing"
+    state = fsm.current_state_name
+    console.log "Got /ping request, mode is "+mode
+  res.json( { resp: "ok", mode: mode, state: state, started: startTime, now: Date.now() } )
+
+# tests need this: jenkins will trigger this
+app.get '/start', (req, res) ->
+  console.log "Got Start testing from the internet: " + req.ip
+
+  data.appName = req.query.app
+  data.img.appId = req.query.appId
+  data.img.network = req.query.net
+  data.img.uiHost = req.query.uiHost
+  data.img.apiHost = req.query.apiHost
+
+  data.credentials.username = req.query.username
+  data.credentials.password = req.query.password
+
+  data.sTim = setTimeout( devTimeout, 1800000)
+  data.state = "started"
+  data.error = ""
+  data.uuid  = ""
+  data.timeout = false
+
+  res.json { state: data.state , started: time, now: Date.now() }
+
+app.get '/startdefault', (req, res) ->
+  if fsm.current_state_name != 'Waiting'
+    console.log 'Test is in progress: [STATE] = '+fsm.current_state_name
+  else
+    console.log 'Starting test with default config'
+    startTest()
+  res.json {resp: "ok", state: fsm.current_state_name}
+
+startTest = () ->
+  console.log 'Starting FSM'
+  startTime = Date.now()
+  fsm.config.initial_state = 'Initialize'
+  fsm.current_state_name = 'Initialize'
+  fsm.start()
+
+console.log 'Starting Server'
+app.listen(8080)

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -52,13 +52,12 @@ app.get '/uuid', (req, res) ->
 
 # tests need this: jenkins will ping to check if device is online
 app.get '/ping', (req, res) ->
-  console.log "Got /ping request"
   if !fsm.current_state_name?
     mode = "free"
   else
     mode = "testing"
     state = fsm.current_state_name
-    console.log "Got /ping request, mode is "+mode
+  console.log "Got /ping request, mode is "+mode
   res.json( { resp: "ok", mode: mode, state: state, started: startTime, now: Date.now() } )
 
 # tests need this: jenkins will trigger this

--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,4 @@ if [ "$INITSYSTEM" != "on" ]; then
   /usr/sbin/sshd -p 80 &
 fi
 
-coffee /usr/src/app/src/main.coffee
+coffee /usr/src/app/src/server.coffee


### PR DESCRIPTION
this PR adds the ability to start a test with the `/startdefault` route which starts a test with some default data
