### PR TITLE
Server interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 ## Auto Test Master
+
+#### TODO:
+
+* proper level logging
+* break out config into its only module
+* login with username & password (??)
+* make multi-device type
+* detect power connected on slave
+* switch to port 80 so can work with jenkins
+* enable console on prod devices, so can talk to bootloader and kernel

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -30,13 +30,14 @@ class AutoTester extends NodeState
           .then (isConnected) ->
             if isConnected
               console.log 'connected to Internet'
+              #TODO: login here with stuff from data object
               #login to resin
               resin.auth.loginWithToken token, (error) ->
                 if error?
                   fsm.goto 'ErrorState' , {error: error}
                 else
                   console.log 'logged into resin.io'
-                  fsm.goto 'DownloadImage'
+                  fsm.goto 'DownloadImage', {data: data}
             else
               error = 'No Internet Connectivity'
               fsm.goto 'ErrorState' , {error: error}
@@ -52,8 +53,15 @@ class AutoTester extends NodeState
             fsm.goto 'ErrorState', {error: error}
 
           if isLoggedIn
-            resin.models.os.download(netParams).then (stream) ->
-              console.log 'Downloading device OS'
+            resin.auth.whoami()
+              .then (username) ->
+                if (!username)
+                  console.log('I\'m not logged in!')
+                else
+                  console.log('Logged in as:', username)
+
+            resin.models.os.download(data.img).then (stream) ->
+              console.log 'Downloading device OS for appID = '+data.
               stream.pipe(fs.createWriteStream(pathToImg))
               stream.on 'error', (err) ->
                 fsm.goto 'ErrorState', {error: err}

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -47,6 +47,7 @@ class AutoTester extends NodeState
       Enter: (data) ->
         fsm = this
         console.log '[STATE] '+@current_state_name
+        console.log 'data: '+data.img
         @wait 200000 # timeout if a download takes longer than 20 minutes
         resin.auth.isLoggedIn (error, isLoggedIn) ->
           if error?

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -37,7 +37,7 @@ class AutoTester extends NodeState
                   fsm.goto 'ErrorState' , {error: error}
                 else
                   console.log 'logged into resin.io'
-                  fsm.goto 'DownloadImage', {data: data}
+                  fsm.goto 'DownloadImage', data
             else
               error = 'No Internet Connectivity'
               fsm.goto 'ErrorState' , {error: error}

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -59,9 +59,9 @@ class AutoTester extends NodeState
                   console.log('I\'m not logged in!')
                 else
                   console.log('Logged in as:', username)
-
-            resin.models.os.download(data.img).then (stream) ->
-              console.log 'Downloading device OS for appID = '+data.
+            params = data.img
+            resin.models.os.download(params).then (stream) ->
+              console.log 'Downloading device OS for appID = '+params.appID
               stream.pipe(fs.createWriteStream(pathToImg))
               stream.on 'error', (err) ->
                 fsm.goto 'ErrorState', {error: err}

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -60,9 +60,10 @@ class AutoTester extends NodeState
                 else
                   console.log('Logged in as:', username)
             params = data.img
+            console.log 'params: '+params
             resin.models.os.download(params).then (stream) ->
-              console.log 'Downloading device OS for appID = '+params.appID
               stream.pipe(fs.createWriteStream(pathToImg))
+              console.log 'Downloading device OS for appID = '+params.appID
               stream.on 'error', (err) ->
                 fsm.goto 'ErrorState', {error: err}
               stream.on 'end', ->

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -64,7 +64,7 @@ class AutoTester extends NodeState
             console.log 'params: '+params
             resin.models.os.download(params).then (stream) ->
               stream.pipe(fs.createWriteStream(pathToImg))
-              console.log 'Downloading device OS for appID = '+params.appID
+              console.log 'Downloading device OS for appID = '+params.appId
               stream.on 'error', (err) ->
                 fsm.goto 'ErrorState', {error: err}
               stream.on 'end', ->

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -28,6 +28,7 @@ app = express()
 # fsm = new AutoTester
 #   initial_data: data #pass in test data here
 #   initial_state: 'Waiting'
+app.locals.fsm = null
 
 app.get '/status', (req, res) ->
   console.log "Got /status request"
@@ -57,7 +58,7 @@ app.get '/ping', (req, res) ->
     state = 'Waiting'
   else
     mode = "testing"
-    state = fsm.current_state_name
+    state = app.locals.fsm.current_state_name
 
   console.log "Got /ping request, mode is "+mode
 
@@ -86,8 +87,8 @@ app.get '/start', (req, res) ->
 
   console.log 'data: '+data
 
-  if fsm.current_state_name != 'Waiting'
-    console.log 'Test is in progress: [STATE] = '+fsm.current_state_name
+  if app.locals.fsm.current_state_name != 'Waiting'
+    console.log 'Test is in progress: [STATE] = '+app.locals.fsm.current_state_name
     mode = 'testing'
   else
     console.log 'Starting test with default config'
@@ -97,15 +98,15 @@ app.get '/start', (req, res) ->
   response =
     resp: "ok"
     mode: mode
-    state: fsm.current_state_name
+    state: app.locals.fsm.current_state_name
     started: startTime
     now: Date.now()
 
   res.json response
 
 app.get '/startdefault', (req, res) ->
-  if fsm.current_state_name != 'Waiting'
-    console.log 'Test is in progress: [STATE] = '+fsm.current_state_name
+  if app.locals.fsm.current_state_name != 'Waiting'
+    console.log 'Test is in progress: [STATE] = '+app.locals.fsm.current_state_name
     mode = 'testing'
   else
     console.log 'Starting test with default config'
@@ -115,7 +116,7 @@ app.get '/startdefault', (req, res) ->
   response =
     resp: "ok"
     mode: mode
-    state: fsm.current_state_name
+    state: app.locals.fsm.current_state_name
     started: startTime
     now: Date.now()
 
@@ -123,7 +124,7 @@ app.get '/startdefault', (req, res) ->
 
 startTest = (testData) ->
   console.log 'data.img: '+testData.img
-  fsm = new AutoTester
+  app.locals.fsm = new AutoTester
     initial_data: testdata #pass in test data here
     initial_state: 'Initialize'
   console.log 'Starting FSM'
@@ -131,7 +132,7 @@ startTest = (testData) ->
   # fsm.config.initial_state = 'Initialize'
   # fsm.current_state_name = 'Initialize'
   # fsm.current_data = testData
-  fsm.start()
+  app.locals.fsm.start()
 
 console.log 'Starting Server'
 app.listen(8080)

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -58,7 +58,13 @@ app.get '/ping', (req, res) ->
     mode = "testing"
     state = fsm.current_state_name
   console.log "Got /ping request, mode is "+mode
-  res.json( { resp: "ok", mode: mode, state: state, started: startTime, now: Date.now() } )
+  response =
+    resp: "ok"
+    mode: mode
+    state: state
+    started: startTime
+    now: Date.now()
+  res.json response
 
 # tests need this: jenkins will trigger this
 app.get '/start', (req, res) ->

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -70,7 +70,7 @@ app.get '/ping', (req, res) ->
   res.json response
 
 # tests need this: jenkins will trigger this
-#/start?username=unicorn-tester@resin.io&password=12345678&appId=3647&app=inuc&net=ethernet&uiHost=https://dashboard.resinstaging.io&apiHost=https://api.resinstaging.io
+#/start?username=unicorn-tester@resin.io&password=12345678&appId=9322&app=alpine&net=ethernet&uiHost=https://dashboard.resin.io&apiHost=https://api.resin.io
 
 app.get '/start', (req, res) ->
   console.log "Got Start testing request from: " + req.ip

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -26,7 +26,7 @@ data =
 
 app = express()
 fsm = new AutoTester
-  initial_data: {data} #pass in test data here
+  initial_data: data #pass in test data here
   initial_state: 'Waiting'
 
 app.get '/status', (req, res) ->
@@ -82,6 +82,8 @@ app.get '/start', (req, res) ->
   data.img.apiHost = req.query.apiHost
   data.credentials.username = req.query.username
   data.credentials.password = req.query.password
+
+  console.log 'data: '+data
 
   if fsm.current_state_name != 'Waiting'
     console.log 'Test is in progress: [STATE] = '+fsm.current_state_name

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -25,9 +25,9 @@ data =
     password: process.env.USER_PASS
 
 app = express()
-fsm = new AutoTester
-  initial_data: data #pass in test data here
-  initial_state: 'Waiting'
+# fsm = new AutoTester
+#   initial_data: data #pass in test data here
+#   initial_state: 'Waiting'
 
 app.get '/status', (req, res) ->
   console.log "Got /status request"
@@ -54,6 +54,7 @@ app.get '/uuid', (req, res) ->
 app.get '/ping', (req, res) ->
   if !fsm.current_state_name?
     mode = "free"
+    state = 'Waiting'
   else
     mode = "testing"
     state = fsm.current_state_name
@@ -121,11 +122,15 @@ app.get '/startdefault', (req, res) ->
   res.json response
 
 startTest = (testData) ->
+  console.log 'data.img: '+testData.img
+  fsm = new AutoTester
+    initial_data: testdata #pass in test data here
+    initial_state: 'Initialize'
   console.log 'Starting FSM'
   startTime = Date.now()
-  fsm.config.initial_state = 'Initialize'
-  fsm.current_state_name = 'Initialize'
-  fsm.current_data = testData
+  # fsm.config.initial_state = 'Initialize'
+  # fsm.current_state_name = 'Initialize'
+  # fsm.current_data = testData
   fsm.start()
 
 console.log 'Starting Server'

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -53,7 +53,7 @@ app.get '/uuid', (req, res) ->
 
 # tests need this: jenkins will ping to check if device is online
 app.get '/ping', (req, res) ->
-  if !fsm.current_state_name?
+  if !fsm.current_state_name? or fsm.current_state_name == 'Waiting'
     mode = "free"
     state = 'Waiting'
   else

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -25,10 +25,10 @@ data =
     password: process.env.USER_PASS
 
 app = express()
-# fsm = new AutoTester
-#   initial_data: data #pass in test data here
-#   initial_state: 'Waiting'
-app.locals.fsm = null
+fsm = new AutoTester
+  initial_data: data #pass in test data here
+  initial_state: 'Waiting'
+
 
 app.get '/status', (req, res) ->
   console.log "Got /status request"
@@ -58,7 +58,7 @@ app.get '/ping', (req, res) ->
     state = 'Waiting'
   else
     mode = "testing"
-    state = app.locals.fsm.current_state_name
+    state = fsm.current_state_name
 
   console.log "Got /ping request, mode is "+mode
 
@@ -85,10 +85,10 @@ app.get '/start', (req, res) ->
   data.credentials.username = req.query.username
   data.credentials.password = req.query.password
 
-  console.log 'data: '+data
+  console.log 'data: '+data.img
 
-  if app.locals.fsm.current_state_name != 'Waiting'
-    console.log 'Test is in progress: [STATE] = '+app.locals.fsm.current_state_name
+  if fsm.current_state_name != 'Waiting'
+    console.log 'Test in progress: [STATE] = '+fsm.current_state_name
     mode = 'testing'
   else
     console.log 'Starting test with default config'
@@ -98,15 +98,15 @@ app.get '/start', (req, res) ->
   response =
     resp: "ok"
     mode: mode
-    state: app.locals.fsm.current_state_name
+    state: fsm.current_state_name
     started: startTime
     now: Date.now()
 
   res.json response
 
 app.get '/startdefault', (req, res) ->
-  if app.locals.fsm.current_state_name != 'Waiting'
-    console.log 'Test is in progress: [STATE] = '+app.locals.fsm.current_state_name
+  if fsm.current_state_name != 'Waiting'
+    console.log 'Test in progress: [STATE] = '+fsm.current_state_name
     mode = 'testing'
   else
     console.log 'Starting test with default config'
@@ -116,7 +116,7 @@ app.get '/startdefault', (req, res) ->
   response =
     resp: "ok"
     mode: mode
-    state: app.locals.fsm.current_state_name
+    state: fsm.current_state_name
     started: startTime
     now: Date.now()
 
@@ -124,15 +124,12 @@ app.get '/startdefault', (req, res) ->
 
 startTest = (testData) ->
   console.log 'data.img: '+testData.img
-  app.locals.fsm = new AutoTester
-    initial_data: testdata #pass in test data here
-    initial_state: 'Initialize'
   console.log 'Starting FSM'
   startTime = Date.now()
-  # fsm.config.initial_state = 'Initialize'
-  # fsm.current_state_name = 'Initialize'
-  # fsm.current_data = testData
-  app.locals.fsm.start()
+  fsm.config.initial_state = 'Initialize'
+  fsm.current_state_name = 'Initialize'
+  fsm.current_data = testData
+  fsm.start()
 
 console.log 'Starting Server'
 app.listen(8080)


### PR DESCRIPTION
[WIP] server now can handle requests on `/start` route to provision device on any arbitrary application. Auth is still done through `TOKEN` but will need to be done via username and pass.  
